### PR TITLE
Bug: Autoscaling Group Initial Instance not attaching ENI & other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module "asg_lambda_role" {
   source = "github.com/corelight/terraform-aws-sensor//modules/iam/lambda"
 
   lambda_cloudwatch_log_group_arn = module.sensor.cloudwatch_log_group_arn
-  sensor_autoscaling_group_name   = module.sensor.autoscaling_group_name
+  sensor_autoscaling_group_arn    = module.sensor.autoscaling_group_arn
   security_group_arn              = module.sensor.management_security_group_arn
   subnet_arn                      = data.aws_subnet.management.arn
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -38,8 +38,8 @@ resource "aws_cloudwatch_event_rule" "asg_lifecycle_rule" {
     "source" : ["aws.autoscaling"],
     "detail-type" : ["EC2 Instance-launch Lifecycle Action"],
     "detail" : {
-      "AutoScalingGroupName" : [aws_autoscaling_group.sensor_asg.name],
-      "LifecycleHookName" : [aws_autoscaling_lifecycle_hook.asg_scale_up_hook.name]
+      "AutoScalingGroupName" : [var.sensor_asg_name],
+      "LifecycleHookName" : [var.asg_lifecycle_hook_name]
     }
   })
 

--- a/modules/bastion/instance.tf
+++ b/modules/bastion/instance.tf
@@ -29,6 +29,7 @@ resource "aws_network_interface" "bastion_nic" {
 }
 
 resource "aws_eip" "bastion_public_ip" {
+  instance          = aws_instance.bastion.id
   network_interface = aws_network_interface.bastion_nic.id
 
   tags = merge({ Name : "${var.bastion_instance_name}-public-ip" }, var.tags)

--- a/modules/iam/lambda/main.tf
+++ b/modules/iam/lambda/main.tf
@@ -1,7 +1,3 @@
-data "aws_autoscaling_group" "asg" {
-  name = var.sensor_autoscaling_group_name
-}
-
 data "aws_iam_policy_document" "lambda_nic_manager_policy" {
   statement {
     effect = "Allow"
@@ -31,7 +27,7 @@ data "aws_iam_policy_document" "lambda_nic_manager_policy" {
       "autoscaling:CompleteLifecycleAction"
     ]
     resources = [
-      data.aws_autoscaling_group.asg.arn
+      var.sensor_autoscaling_group_arn
     ]
   }
 
@@ -46,7 +42,7 @@ data "aws_iam_policy_document" "lambda_nic_manager_policy" {
     ]
     condition {
       test     = "StringEquals"
-      values   = [data.aws_autoscaling_group.asg.name]
+      values   = [split("/", var.sensor_autoscaling_group_arn)[1]]
       variable = "aws:ResourceTag/aws:autoscaling:groupName"
     }
   }

--- a/modules/iam/lambda/variables.tf
+++ b/modules/iam/lambda/variables.tf
@@ -3,7 +3,7 @@ variable "lambda_cloudwatch_log_group_arn" {
   type        = string
 }
 
-variable "sensor_autoscaling_group_name" {
+variable "sensor_autoscaling_group_arn" {
   description = "ARN of the sensor EC2 autoscaling group of Corelight sensors"
   type        = string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "auto_scale_group_arn" {
+output "autoscaling_group_arn" {
   value = aws_autoscaling_group.sensor_asg.arn
 }
 


### PR DESCRIPTION
# Description

**Bastion Module Bug**
Fixed an issue with the Bastion module where the EIP was being attached before the instance was available

**Autoscaling Group Bug**
Fixed an issue where the autoscaling group was not provisioning the initial instance using the lambda to attach the second ENI. This was due to a race condition where the lambda IAM policy was waiting for the ASG to fully spin up its first instance prior to assigning the role to the lambda. By the time the ASG finished, it was too late to run the lambda on the first instance. 

`wait_for_capacity_timeout = 0` was added so the TF module does not wait for the first instance to be provisioned and provides the lambda IAM policy with the ASG ARN before the first instance is created. Also moved the lifecycle hook into the ASG config as the `initial_lifecycle_hook` so that it will be triggered on the first instance provisioned. 

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] New Feature
- [x] This change requires a documentation update

# How Has This Been Tested?

Deploy several times with local version of the code. It consistently deployed all resources correctly
