### PR TITLE
Bugfix: Load Zeek script after cloud enrichment enabled

### DIFF
--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -1,5 +1,5 @@
 module "sensor_config" {
-  source = "github.com/corelight/terraform-config-sensor"
+  source = "github.com/corelight/terraform-config-sensor?ref=v0.1.0"
 
   sensor_license                   = var.license_key
   fleet_community_string           = var.community_string


### PR DESCRIPTION
# Description
Pinning sensor config to v0.1.0 version until v27.14.0 of the software sensor is released to address a bug where the cloud enrichment zeek script was not being loaded automatically

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested successfully local
