### PR TITLE
support fleet configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ module "asg_lambda_role" {
 module "sensor" {
   source = "github.com/corelight/terraform-aws-sensor"
 
-  # Recommend deploying a sensor per availability zone. Multiple AZs can 
+  # Recommend deploying a sensor per availability zone. Multiple AZs can
   # be set but GWLB cross availability zone support is not recommended.
   auto_scaling_availability_zones = ["<availability zone>"]
   aws_key_pair_name = "<key pair name>"
-  
+
   # Request access to Corelight sensor AMI from you Account Executive
   corelight_sensor_ami_id = "<sensor AMI ID>"
   license_key = "<your Corelight sensor license key>"
@@ -36,13 +36,18 @@ module "sensor" {
   community_string = "<password for the sensor api>"
   vpc_id = "<vpc where the sensor autoscaling group is deployed>"
   asg_lambda_iam_role_arn = module.asg_lambda_role.role_arn
-  
-  # (Optional) ASG should have an instance profile when using 
+
+  # (Optional) ASG should have an instance profile when using
   # the cloud enrichment feature
   enrichment_bucket_name = "<cloud enrichment s3 bucket name>"
   enrichment_bucket_region = "<cloud enrichment s3 bucket region>"
   enrichment_instance_profile_arn = aws_iam_instance_profile.corelight_sensor.arn
+
+  # Optional - Fleet Manager
+  fleet_token = "<the pairing token from the Fleet UI>"
+  fleet_url   = "<the URL of the fleet instance from the Fleet UI>"
 }
+
 
 ### Optional resources for enrichment
 module "enrichment_sensor_role" {

--- a/examples/deployment/main.tf
+++ b/examples/deployment/main.tf
@@ -9,6 +9,8 @@ locals {
     terraform : true,
     purpose : "Corelight"
   }
+  fleet_token = "b1cd099ff22ed8a41abc63929d1db126"
+  fleet_url   = "https://fleet.example.com:1443/fleet/v1/internal/softsensor/websocket"
 }
 
 data "aws_subnet" "management" {
@@ -38,6 +40,8 @@ module "sensor" {
   community_string                = "<password for the sensor api>"
   vpc_id                          = local.vpc_id
   asg_lambda_iam_role_arn         = module.asg_lambda_role.role_arn
+  fleet_token                     = local.fleet_token
+  fleet_url                       = local.fleet_url
 
   tags = local.tags
 }

--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -3,6 +3,12 @@ module "sensor_config" {
 
   sensor_license                   = var.license_key
   fleet_community_string           = var.community_string
+  fleet_token                      = var.fleet_token
+  fleet_url                        = var.fleet_url
+  fleet_server_sslname             = var.fleet_server_sslname
+  fleet_http_proxy                 = var.fleet_http_proxy
+  fleet_https_proxy                = var.fleet_https_proxy
+  fleet_no_proxy                   = var.fleet_no_proxy
   sensor_management_interface_name = "eth1"
   sensor_monitoring_interface_name = "eth0"
   base64_encode_config             = true

--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -1,5 +1,5 @@
 module "sensor_config" {
-  source = "github.com/corelight/terraform-config-sensor?ref=v0.2.0"
+  source = "github.com/corelight/terraform-config-sensor?ref=v0.3.0"
 
   sensor_license                   = var.license_key
   fleet_community_string           = var.community_string

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,41 @@ variable "tags" {
   type        = object({})
   default     = {}
 }
+
+variable "fleet_token" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "(optional) the pairing token from the Fleet UI. Must be set if 'fleet_url' is provided"
+}
+
+variable "fleet_url" {
+  type        = string
+  default     = ""
+  description = "(optional) the URL of the fleet instance from the Fleet UI. Must be set if 'fleet_token' is provided"
+}
+
+variable "fleet_server_sslname" {
+  type        = string
+  default     = "1.broala.fleet.product.corelight.io"
+  description = "(optional) the SSL hostname for the fleet server"
+
+}
+
+variable "fleet_http_proxy" {
+  type        = string
+  default     = ""
+  description = "(optional) the proxy URL for HTTP traffic from the fleet"
+}
+
+variable "fleet_https_proxy" {
+  type        = string
+  default     = ""
+  description = "(optional) the proxy URL for HTTPS traffic from the fleet"
+}
+
+variable "fleet_no_proxy" {
+  type        = string
+  default     = ""
+  description = "(optional) hosts or domains to bypass the proxy for fleet traffic"
+}


### PR DESCRIPTION
# Description

Ability to pair the sensor to Fleet.

Fixes #CLOUD-270, but depends on https://github.com/corelight/terraform-config-sensor/pull/10

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally