### PR TITLE
v1.0.0 Corelight Config and Fleet Now Required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[#](#) terraform-aws-sensor
+# terraform-aws-sensor
 
 Terraform for Corelight's AWS Cloud Sensor Deployment.
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,10 @@ module "sensor" {
   community_string = "<password for the sensor api>"
   vpc_id = "<vpc where the sensor autoscaling group is deployed>"
   asg_lambda_iam_role_arn = module.asg_lambda_role.role_arn
-
-  # (Optional) ASG should have an instance profile when using
-  # the cloud enrichment feature
-  enrichment_bucket_name = "<cloud enrichment s3 bucket name>"
-  enrichment_bucket_region = "<cloud enrichment s3 bucket region>"
-  enrichment_instance_profile_arn = aws_iam_instance_profile.corelight_sensor.arn
-
-  # Optional - Fleet Manager
+  
   fleet_token = "<the pairing token from the Fleet UI>"
   fleet_url   = "<the URL of the fleet instance from the Fleet UI>"
+  fleet_server_sslname = "<the ssl name provided by Fleet>"
 }
 
 

--- a/data.tf
+++ b/data.tf
@@ -5,7 +5,3 @@ data "aws_vpc" "provided" {
 data "aws_subnet" "monitoring_subnet" {
   id = var.monitoring_subnet_id
 }
-
-data "aws_subnet" "management_subnet" {
-  id = var.management_subnet_id
-}

--- a/launch_template.tf
+++ b/launch_template.tf
@@ -7,10 +7,10 @@ resource "aws_launch_template" "sensor_launch_template" {
   ebs_optimized = false
 
   dynamic "iam_instance_profile" {
-    for_each = var.enrichment_instance_profile_arn == "" ? toset([]) : toset([1])
+    for_each = var.instance_profile_arn == "" ? toset([]) : toset([1])
 
     content {
-      arn = var.enrichment_instance_profile_arn
+      arn = var.instance_profile_arn
     }
   }
 

--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -1,5 +1,5 @@
 module "sensor_config" {
-  source = "github.com/corelight/terraform-config-sensor?ref=v0.3.0"
+  source = "github.com/corelight/terraform-config-sensor?ref=v1.0.0"
 
   sensor_license                   = var.license_key
   fleet_community_string           = var.community_string
@@ -13,9 +13,4 @@ module "sensor_config" {
   sensor_monitoring_interface_name = "eth0"
   base64_encode_config             = true
   sensor_health_check_http_port    = "41080"
-
-  enrichment_enabled             = var.enrichment_bucket_name != "" && var.enrichment_bucket_region != ""
-  enrichment_bucket_name         = var.enrichment_bucket_name
-  enrichment_bucket_region       = var.enrichment_bucket_region
-  enrichment_cloud_provider_name = "aws"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,22 @@ variable "community_string" {
   sensitive   = true
 }
 
+variable "fleet_token" {
+  type        = string
+  sensitive   = true
+  description = "Pairing token from the Fleet UI. Must be set if 'fleet_url' is provided"
+}
+
+variable "fleet_url" {
+  type        = string
+  description = "URL of the fleet instance from the Fleet UI. Must be set if 'fleet_token' is provided"
+}
+
+variable "fleet_server_sslname" {
+  type        = string
+  description = "SSL hostname for the fleet server"
+}
+
 variable "license_key" {
   description = "Your Corelight sensor license key. Optional if fleet_url is configured."
   sensitive   = true
@@ -125,20 +141,8 @@ variable "sensor_management_security_group_description" {
   default     = "Security group for the sensor which allows ssh from the DMZ / Bastion"
 }
 
-variable "enrichment_bucket_name" {
-  description = "(optional) The name of the s3 bucket where cloud enrichment data is being stored"
-  type        = string
-  default     = ""
-}
-
-variable "enrichment_bucket_region" {
-  description = "(optional) The region of the cloud enrichment s3 bucket"
-  type        = string
-  default     = ""
-}
-
-variable "enrichment_instance_profile_arn" {
-  description = "(optional) When configuring enrichment, an instance profile must be added granting the ASG EC2 nodes access to read from the bucket"
+variable "instance_profile_arn" {
+  description = "(optional) Instance profile must be added granting cloud features access to AWS APIs"
   type        = string
   default     = ""
 }
@@ -177,26 +181,6 @@ variable "tags" {
   description = "(optional) Any tags that should be applied to resources deployed by the module"
   type        = object({})
   default     = {}
-}
-
-variable "fleet_token" {
-  type        = string
-  default     = ""
-  sensitive   = true
-  description = "(optional) the pairing token from the Fleet UI. Must be set if 'fleet_url' is provided"
-}
-
-variable "fleet_url" {
-  type        = string
-  default     = ""
-  description = "(optional) the URL of the fleet instance from the Fleet UI. Must be set if 'fleet_token' is provided"
-}
-
-variable "fleet_server_sslname" {
-  type        = string
-  default     = "1.broala.fleet.product.corelight.io"
-  description = "(optional) the SSL hostname for the fleet server"
-
 }
 
 variable "fleet_http_proxy" {


### PR DESCRIPTION
# Description

- Pinning sensor config to v1.0.0
- Removing automated configuration of Cloud Enrichment service
- Fleet configuration is now mandatory

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update
