### PR TITLE
Include IMDSv2 options

### DIFF
--- a/launch_template.tf
+++ b/launch_template.tf
@@ -14,6 +14,13 @@ resource "aws_launch_template" "sensor_launch_template" {
     }
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+
   block_device_mappings {
     device_name = var.sensor_launch_template_volume_name
 


### PR DESCRIPTION
Following TF best practice example for adding IMDSv2 in AWS launch template. Corrects Issue #29. 

# Description

Include code block in AWS launch template for http options based on TF's _launch template_ [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template).

## Type of change

- [✅] New Feature
