### PR TITLE
fix: hop limit for cloud services

### DIFF
--- a/launch_template.tf
+++ b/launch_template.tf
@@ -16,8 +16,9 @@ resource "aws_launch_template" "sensor_launch_template" {
 
   # CKV_AWS_79: Enforce IMDSv2 (Instance Metadata Service Version 2)
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
   }
 
   block_device_mappings {


### PR DESCRIPTION
# Description

Updating the IMDS configuration to allow for k8s pods to use the instance profile IAM role

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Modified config manually to resolve the issue
```
aws ec2 modify-instance-metadata-options \
      --instance-id i-xxxxxxxx \
      --http-put-response-hop-limit 2 \
      --http-endpoint enabled
