### PR TITLE
IAM Role module parameter fix and enhance documentation (Fixes #34)

### DIFF
--- a/modules/iam/lambda/main.tf
+++ b/modules/iam/lambda/main.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 }
 
 resource "aws_iam_role" "lambda_nic_manager_role" {
-  name               = var.lambda_role_arn
+  name               = var.lambda_role_name
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
   tags               = var.tags
 }

--- a/modules/iam/lambda/variables.tf
+++ b/modules/iam/lambda/variables.tf
@@ -18,8 +18,8 @@ variable "security_group_arn" {
   type        = string
 }
 
-variable "lambda_role_arn" {
-  description = "ARN of the ENI management lambda role"
+variable "lambda_role_name" {
+  description = "Name of the ENI management lambda role"
   type        = string
   default     = "corelight-asg-sensor-nic-manager-lambda-role"
 }


### PR DESCRIPTION
Summary

Fixes a misleading variable name in the IAM Lambda module and adds comprehensive documentation for multi-region deployments in response to https://github.com/corelight/terraform-aws-sensor/issues/34.

Changes

 Bug Fix:
  - Renamed lambda_role_arn → lambda_role_name in modules/iam/lambda/
  - Variable was used as the role's name parameter, not as an ARN
  - Updated description to match actual usage

 Documentation:
  - Added architecture section explaining the two-module design
  - Documented required vs optional resources
  - Added complete multi-region deployment example with provider aliasing
  - Shows how to use lambda_role_name parameter for unique naming per region
  - Clarified which resources are region-specific vs global

 Breaking Change

Variable rename is technically breaking, but most users rely on the default value which remains unchanged. The old name was misleading and caused confusion.
