### PR TITLE
add creation of gateway load balancer endpoint service to module

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -30,3 +30,15 @@ resource "aws_lb_target_group" "health_check" {
     unhealthy_threshold = 10
   }
 }
+
+resource "aws_vpc_endpoint_service" "gwlb_service" {
+  acceptance_required        = var.vpc_endpoint_service_acceptance_required
+  gateway_load_balancer_arns = [aws_lb.sensor_lb.arn]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.sensor_asg_load_balancer_name}-service"
+    },
+  )
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,3 +49,11 @@ output "management_security_group_arn" {
 output "cloudwatch_log_group_arn" {
   value = aws_cloudwatch_log_group.log_group.arn
 }
+
+output "vpc_endpoint_service_name" {
+  value = aws_vpc_endpoint_service.gwlb_service.service_name
+}
+
+output "vpc_endpoint_service_id" {
+  value = aws_vpc_endpoint_service.gwlb_service.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -237,3 +237,9 @@ variable "fedramp_mode_enabled" {
   default     = false
   description = "(optional) enable Fedramp mode"
 }
+
+variable "vpc_endpoint_service_acceptance_required" {
+  type        = bool
+  default     = false
+  description = "(optional) Whether to require acceptance of the VPC endpoint"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,13 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5"
     }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2"
+    }
   }
 }


### PR DESCRIPTION
# Description

This is a feature enhancement that automatically creates the VPC endpoint service linked to the gateway load balancer. This is a basic requirement for mirroring traffic to the gwlb and will save clients manual effort creating them. Also added required versions to resolve tflint warnings.

## Type of change




- [ x ] New Feature


# How Has This Been Tested?

This has been deployed in the lab and to client environments.
